### PR TITLE
MAID-3109: droplet deployer: support any digital ocean account

### DIFF
--- a/droplet_deployer/.jshintrc
+++ b/droplet_deployer/.jshintrc
@@ -17,6 +17,7 @@
   "eqnull": true,
   "maxerr": 30,
   "node": true,
+  "esnext": true,
   "globals"   : {
     "describe": false,
     "it": false,

--- a/droplet_deployer/README.md
+++ b/droplet_deployer/README.md
@@ -41,6 +41,34 @@ deployer parameters.
   for digital ocean API authentication. If this value is not specified, it will
   be retrieved from `auth_repo`.
   Example: "a2e053aea17b84085a794c77005aa0726a418bfc18b4e1550d36abc6d14cacab"
+* `providerDetails` {object} - droplet provider specific configs.
+  Example:
+
+```json
+  "providerDetails": {
+    "digitalOcean": {
+      "snapshotId": "37206537",
+      "concentratedRegion": "lon1",
+      "size": "s-1vcpu-2gb"
+    }
+  }
+```
+* `providerDetails.providerName.freshInstall` {bool} - if true install
+  dependencies to a newly created droplet. If you're using a snaphsot image
+  with already installed dependencies, either leave this option unspecified
+  or make it `false`.
+  Example:
+
+```json
+  "providerDetails": {
+    "digitalOcean": {
+      "freshInstall": true,
+      "snapshotId": "37206537",
+      "concentratedRegion": "lon1",
+      "size": "s-1vcpu-2gb"
+    }
+  }
+```
 
 ## TODO
   At present the droplet list from digitalocean fetches maximum of 500 droplets only.

--- a/droplet_deployer/README.md
+++ b/droplet_deployer/README.md
@@ -8,7 +8,8 @@ Linux only (DigitalOcean only supports Linux)
 
 ## Prerequisite
 
-[Nodejs](https://nodejs.org/en/download/) should be installed.
+[Nodejs](https://nodejs.org/en/download/) should be installed. The minimum
+version is `8.11.3`.
 
 Linux:
 
@@ -28,6 +29,7 @@ run `npm install`
 ## Usage
 
 `npm start` - Follow the default flow of the tool as listed [here](script_flow.md)
+`grunt  test` - Run lint checks.
 
 ## Configs
 

--- a/droplet_deployer/README.md
+++ b/droplet_deployer/README.md
@@ -29,6 +29,16 @@ run `npm install`
 
 `npm start` - Follow the default flow of the tool as listed [here](script_flow.md)
 
+## Configs
+
+There is `config.json` file which allows you to tweek somer of the droplet
+deployer parameters.
+
+* `dropletSshPrivKeyPath` - full path to the private key used for SSH
+  connection. If not specified, username/password authentication will be used.
+  Example: "/home/povilas/.ssh/id_rsa"
+
+
 ## TODO
   At present the droplet list from digitalocean fetches maximum of 500 droplets only.
   Implement proper pagination based on the meta data

--- a/droplet_deployer/README.md
+++ b/droplet_deployer/README.md
@@ -37,7 +37,10 @@ deployer parameters.
 * `dropletSshPrivKeyPath` - full path to the private key used for SSH
   connection. If not specified, username/password authentication will be used.
   Example: "/home/povilas/.ssh/id_rsa"
-
+* `digitalOceanToken` - basically what it says on the tin: use the give token
+  for digital ocean API authentication. If this value is not specified, it will
+  be retrieved from `auth_repo`.
+  Example: "a2e053aea17b84085a794c77005aa0726a418bfc18b4e1550d36abc6d14cacab"
 
 ## TODO
   At present the droplet list from digitalocean fetches maximum of 500 droplets only.

--- a/droplet_deployer/common/auth.js
+++ b/droplet_deployer/common/auth.js
@@ -28,6 +28,12 @@ var AuthManager = function() {
   };
 
   var cloneRepo = function(callback) {
+    // If we have specified SSH private key, we don't need credentials repo.
+    if ('dropletSshPrivKeyPath' in config) {
+      callback(null);
+      return;
+    }
+
     exec('git clone ' + config.auth_repo + ' ' + config.workspace + '/' +
       CLONED_REPO_NAME + ' --depth 1', function(err) {
       if (err) {

--- a/droplet_deployer/setup_network.js
+++ b/droplet_deployer/setup_network.js
@@ -56,12 +56,19 @@ exports = module.exports = function(args) {
    *    specific options, e.g. for authentication.
    */
   function makeSSHOptions(ip, config) {
-      return {
-        host: ip,
-        username: config.dropletUser,
-        password: auth.getDropletUserPassword(),
-        readyTimeout: 99999
-      };
+    var opts =  {
+      host: ip,
+      username: config.dropletUser,
+      readyTimeout: 99999
+    };
+
+    if ('dropletSshPrivKeyPath' in config) {
+      opts.privateKey = fs.readFileSync(config.dropletSshPrivKeyPath);
+    } else {
+      opts.password = auth.getDropletUserPassword();
+    }
+
+    return opts;
   }
 
   // Helper fn to populate ssh requests to multiple ips

--- a/droplet_deployer/setup_network.js
+++ b/droplet_deployer/setup_network.js
@@ -466,7 +466,7 @@ exports = module.exports = function(args) {
    * Installs required packages into the droplets.
    */
   function setupDroplets(callback) {
-    if (isUsingExistingDroplets) {
+    if (!PROVIDER_DETAILS.freshInstall) {
       return callback();
     }
 


### PR DESCRIPTION
I had several issues with running droplet deployer with my personal digital ocean account:
1. deployer uses some specific DO snapshot that is not available for my account
2. the scripts use github.com/maidsafe/assets repo to acquire SSH auth information. This repo is also not accessible to everyone

This PR addresses the mentioned issues and 
1. uses generic Ubuntu 16 image and install required dependencies: ruby and teamocil. This makes droplets more reproducible
2. introduces new config option to specify SSH keys for authentication

Note that these changes are optional and should not break the current behavior.