### PR TITLE
chore/deployer: update droplet deployer ID

### DIFF
--- a/droplet_deployer/config.json
+++ b/droplet_deployer/config.json
@@ -40,7 +40,7 @@
   "provider": "digitalOcean",
   "providerDetails": {
     "digitalOcean": {
-      "snapshotId": "33346667",
+      "snapshotId": "52015304",
       "concentratedRegion": "lon1",
       "size": "s-1vcpu-2gb"
     },


### PR DESCRIPTION
I've created a new snapshot on Digital Ocean - this PR updates the droplet deployer tool to use the new snapshot