### PR TITLE
Allow Boost Software License 1.0 (BSL-1.0)

### DIFF
--- a/misc-scripts/deny.toml
+++ b/misc-scripts/deny.toml
@@ -75,6 +75,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "CC0-1.0",
     "ISC",
     "Zlib"


### PR DESCRIPTION
BSL-1.0 is another permissive license, a few of the low-level crates are licensed under BSL which is causing our cargo-deny to fail.

https://opensource.org/licenses/BSL-1.0