### PR TITLE
chore: ignore chrono advisories for cargo-deny

### DIFF
--- a/misc-scripts/deny.toml
+++ b/misc-scripts/deny.toml
@@ -48,7 +48,8 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+    "RUSTSEC-2020-0159",
+    "RUSTSEC-2020-0071",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
Ignores a couple of advisories related to the `chrono` crate. The example configuration for `cargo-deny` indicates that these issues haven't been a problem in practice:
https://embarkstudios.github.io/cargo-deny/checks/cfg.html

We've made some changes for these advisories that are causing some problems and are going to be reverted.