### PR TITLE
chore: allow unicode dfs 2016 license

### DIFF
--- a/misc-scripts/deny.toml
+++ b/misc-scripts/deny.toml
@@ -79,6 +79,7 @@ allow = [
     "BSL-1.0",
     "CC0-1.0",
     "ISC",
+    "Unicode-DFS-2016",
     "Zlib"
 ]
 # List of explictly disallowed licenses


### PR DESCRIPTION
The `unicode-ident` crate is now in the dependency graph for `secured_linked_list` and this crate is using MIT, Apache 2.0 and Unicode-DFS-2016 licenses.

We need to whitelist this license type otherwise `cargo-deny` rejects it at PR.